### PR TITLE
fix the scope of optimizer

### DIFF
--- a/train.py
+++ b/train.py
@@ -259,7 +259,7 @@ if __name__ == '__main__':
     clf_head = ClfHead(clf_token, args)
 
     criterion = nn.CrossEntropyLoss(reduce=False) # TODO check loss functions
-    model_opt = OpenAIAdam(model.parameters(), lr=lr, schedule=lr_schedule,
+    model_opt = OpenAIAdam(list(model.parameters()) + list(clf_head.parameters()), lr=lr, schedule=lr_schedule,
                             warmup=lr_warmup, t_total=n_updates_total, b1=b1,
                             b2=b2, e=e, l2=l2, vector_l2=vector_l2,
                             max_grad_norm=max_grad_norm)


### PR DESCRIPTION
The target of an optimizer should contain `clf_head` (new task-specific output matrix) in addition to `model` (Transformer encoder).
The code might fail to do that, right?