### PR TITLE
Using negative index to reshape the input tensor.

### DIFF
--- a/model_py.py
+++ b/model_py.py
@@ -157,7 +157,7 @@ class Model(nn.Module):
         nn.init.normal_(self.embed.weight, std=0.02)
 
     def forward(self, x):
-        x = x.view(-1, x.size(2), x.size(3))
+        x = x.view(-1, x.size(-2), x.size(-1))
         e = self.embed(x)
         h = e.sum(dim=2)
         for block in self.h:


### PR DESCRIPTION
Hi,

This is a really simple patch that allows more flexibility with the size of the input tensor. 

In the code example, the task used for the finetuning of the model takes a pair of sentences as input so the tensor is of shape `(batch, sentence index, sequence length, data or position index)`. Now let's say I want to use the model to do language modelling, I would like my input shape to simply be `(batch, sequence_length, data or position index)` which is not possible with the current version of the code. 

My commit fixes this. By using negative indices, the model can now take both tensor shapes as input.