### PR TITLE
Cleaning the data encoding code.

### DIFF
--- a/train.py
+++ b/train.py
@@ -236,7 +236,7 @@ if __name__ == '__main__':
     print("Encoding dataset...")
     ((trX1, trX2, trX3, trY),
      (vaX1, vaX2, vaX3, vaY),
-     (teX1, teX2, teX3)) = encode_dataset(rocstories(data_dir, n_valid=args.n_valid),
+     (teX1, teX2, teX3)) = encode_dataset(*rocstories(data_dir, n_valid=args.n_valid),
                                           encoder=text_encoder)
     encoder['_start_'] = len(encoder)
     encoder['_delimiter_'] = len(encoder)

--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 def encode_dataset(*splits, encoder):
     encoded_splits = []
-    for split in splits[0]:
+    for split in splits:
         fields = []
         for field in split:
             if isinstance(field[0], str):


### PR DESCRIPTION
A small modification to the call of the `encode_dataset` function. 

The old version of the `encode_dataset` takes a variable number of arguments but only uses the first unnamed one and the named one which does not make sense. With the patch, the return of `rocstories` gets split into the arguments of `encode_dataset`.  