### PR TITLE
Using the ellipsis to allow the function to work with dim 3 or 4 tensors

### DIFF
--- a/model_pytorch.py
+++ b/model_pytorch.py
@@ -203,7 +203,7 @@ class ClfHead(nn.Module):
     def forward(self, h, x):
         # Classification logits
         clf_h = h.view(-1, self.n_embd)
-        flat = x[:, :, :, 0].contiguous().view(-1)
+        flat = x[..., 0].contiguous().view(-1)
         clf_h = clf_h[flat == self.clf_token, :]
         clf_h = clf_h.view(-1, x.size(1), self.n_embd, 1)
         clf_h = self.dropout(clf_h)


### PR DESCRIPTION
This pull request has the same purpose as #8, allowing the network to work generically with various tensor shapes. 

The Ellipsis `...` allows to select all the dimensions before the last one.