### PR TITLE
Removing python 2.7 check from Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ group: travis_latest
 language: python
 cache: pip
 python:
-    - 2.7
+    #- 2.7
     - 3.6
     #- nightly
     #- pypy


### PR DESCRIPTION
I do not think that this code is meant to be run with Python 2.7 so I removed this check from the Travis file.