### PR TITLE
Noise shape dropout

### DIFF
--- a/model_pytorch.py
+++ b/model_pytorch.py
@@ -206,8 +206,12 @@ class ClfHead(nn.Module):
         flat = x[:, :, :, 0].contiguous().view(-1)
         clf_h = clf_h[flat == self.clf_token, :]
         clf_h = clf_h.view(-1, x.size(1), self.n_embd, 1)
+        # This double transposition is there to replicate the behavior
+        # of the noise_shape argument in the tensorflow
+        # implementation.  For more details, see
+        # https://github.com/huggingface/pytorch-openai-transformer-lm/issues/11
         clf_h = self.dropout(clf_h.transpose(1, 2)).transpose(1, 2)
-        clf_h = clf_h.continuous.view(-1, self.n_embd)
+        clf_h = clf_h.contiguous().view(-1, self.n_embd)
         clf_logits = self.linear(clf_h)
         return clf_logits.view(-1, x.size(1))
 

--- a/model_pytorch.py
+++ b/model_pytorch.py
@@ -206,8 +206,8 @@ class ClfHead(nn.Module):
         flat = x[:, :, :, 0].contiguous().view(-1)
         clf_h = clf_h[flat == self.clf_token, :]
         clf_h = clf_h.view(-1, x.size(1), self.n_embd, 1)
-        clf_h = self.dropout(clf_h)
-        clf_h = clf_h.view(-1, self.n_embd)
+        clf_h = self.dropout(clf_h.transpose(1, 2)).transpose(1, 2)
+        clf_h = clf_h.continuous.view(-1, self.n_embd)
         clf_logits = self.linear(clf_h)
         return clf_logits.view(-1, x.size(1))
 


### PR DESCRIPTION
Reproducing the specific behavior of the classifier dropout of the original OpenAI implementation of the article. The details of the this patch can be found in issue #11.