### PR TITLE
Use the embedding dropout

### DIFF
--- a/model_pytorch.py
+++ b/model_pytorch.py
@@ -166,7 +166,7 @@ class TransformerModel(nn.Module):
 
     def forward(self, x):
         x = x.view(-1, x.size(-2), x.size(-1))
-        e = self.embed(x)
+        e = self.drop(self.embed(x))
         # Add the position information to the input embeddings
         h = e.sum(dim=2)
         for block in self.h:


### PR DESCRIPTION
I don't know if the embedding dropout is defined by mistake (haven't check the tf implementation) but it's not used in the forward pass. This PR fixes it.
If it shouldn't be there at all, then the dropout and the `embd_pdrop` in the default config should probably be removed.